### PR TITLE
set compile version of apache lang3 to 3.0.1 in order to support AEM 6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,10 +89,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.osgi</artifactId>
         </dependency>
         <dependency>
@@ -377,7 +373,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.4</version>
+                <version>3.0.1</version>
                 <scope>provided</scope>
             </dependency>
             <!-- test -->


### PR DESCRIPTION
and remove duplicate entry for sling-api which causes a warning

