### PR TITLE
bug fixes: runable from default config, index error / additional configs

### DIFF
--- a/src/main/java/df/aem/jmx2log/JmxToLogConfig.java
+++ b/src/main/java/df/aem/jmx2log/JmxToLogConfig.java
@@ -12,5 +12,9 @@ public @interface JmxToLogConfig {
 
     String schedulerExpression() default "0 * * * * ?";
 
+    String loggerName() default "jmx2log";
+
+    String messageTemplate() default "";
+
 
 }

--- a/src/main/java/df/aem/jmx2log/impl/JmxToLogService.java
+++ b/src/main/java/df/aem/jmx2log/impl/JmxToLogService.java
@@ -63,7 +63,7 @@ public class JmxToLogService implements Runnable {
             }
             String[] parts = strSearchConfig.split("\\|");
             String namePattern = parts[0];
-            String attributePattern = parts.length > 0 ? parts[1] : "";
+            String attributePattern = parts.length > 1 ? parts[1] : "";
             searchConfigs.add(new SearchConfig(namePattern, attributePattern));
         }
 


### PR DESCRIPTION
on aem 6.0 no job from default config is spawned anymore
index lookup is corrected for parsed configuration
logger name is configurable
values in logging message can be configured to reduce ambiguity 

