### PR TITLE
Update of log-pattern with "mBean name and path".

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The name of the logger to log bean attributes to. All logging to this logger wil
 
 **Property: Message Template**
 
-This template will be used to create log messages. Defaults to '{1}: {2}'.
+This template will be used to create log messages. Defaults to '{5}:{1}: {2}'.
 
 Arbitrary text can be specified as defined by [java.text.MessageFormat](https://docs.oracle.com/javase/8/docs/api/java/text/MessageFormat.html).
 Following placeholders can be used:
@@ -52,6 +52,7 @@ Following placeholders can be used:
 - **{2}**: Value of property
 - **{3}**: Bean pattern
 - **{4}**: Property pattern (messageTemplate)
+- **{5}**: mBean path and name
 
 **Property: Search**
 

--- a/src/main/java/df/aem/jmx2log/ReadJmxService.java
+++ b/src/main/java/df/aem/jmx2log/ReadJmxService.java
@@ -23,6 +23,7 @@ public interface ReadJmxService {
      * Looks up all mBeans on local mBean server that match pattern.
      *
      * If no such mBean exists, a NoSuchMBeanException will be thrown.
+     * 
      * @param pattern The pattern to match names of mbeans against
      * @return Set of matching {@link ObjectName}s
      * @throws NoSuchMBeanException if no matching MBean exists.
@@ -34,24 +35,30 @@ public interface ReadJmxService {
      *
      * @param mBean The mbean to evaluate
      * @return an iterable over all the values that have been extracted during run
-     * @throws CouldNotReadJmxValueException if something goes wrong while reading any value
-     * @throws NoSuchAttributeException if mbean does not contain any attribute
+     * @throws CouldNotReadJmxValueException if something goes wrong while reading
+     *                                       any value
+     * @throws NoSuchAttributeException      if mbean does not contain any attribute
      */
     Iterable<MBeanAttribute> attributes(ObjectName mBean) throws CouldNotReadJmxValueException;
 
     /**
      * Evaluates all attributes on mbean that match namePattern.
      *
-     * @param mBean The MBean to evaluate
+     * @param mBean       The MBean to evaluate
      * @param namePattern The pattern attributes of mbean will be matched against
      * @return an iterable over all the values that have been extracted during run
-     * @throws CouldNotReadJmxValueException if something goes wrong while reading any value
-     * @throws NoSuchAttributeException if something is wrong with the configuration -> no matching attribute on mbean
+     * @throws CouldNotReadJmxValueException if something goes wrong while reading
+     *                                       any value
+     * @throws NoSuchAttributeException      if something is wrong with the
+     *                                       configuration -> no matching attribute
+     *                                       on mbean
      */
     Iterable<MBeanAttribute> attributes(ObjectName mBean, String namePattern)
             throws CouldNotReadJmxValueException, NoSuchAttributeException;
 
     interface MBeanAttribute {
+        String mbean();
+
         String name();
 
         String type();

--- a/src/main/java/df/aem/jmx2log/impl/JmxToLogService.java
+++ b/src/main/java/df/aem/jmx2log/impl/JmxToLogService.java
@@ -22,12 +22,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * Created by Dominik Foerderreuther df@adobe.com on 25.12.17.
  */
 @Service(Runnable.class)
-@Component(metatype=true,
-        label="JMX to Log", description="Write JMX values continuously to logfile",
-        configurationFactory = true, policy = ConfigurationPolicy.REQUIRE)
+@Component(metatype = true, label = "JMX to Log", description = "Write JMX values continuously to logfile", configurationFactory = true, policy = ConfigurationPolicy.REQUIRE)
 @Properties({
-    @Property(name = "scheduler.concurrent", boolValue = false),
-    @Property(name = "scheduler.expression", value = "0 * * * * ?")
+        @Property(name = "scheduler.concurrent", boolValue = false),
+        @Property(name = "scheduler.expression", value = "0 * * * * ?")
 })
 public class JmxToLogService implements Runnable {
 
@@ -37,19 +35,17 @@ public class JmxToLogService implements Runnable {
     private static final String LOGGER_NAME_DEFAULT = "jmx2log";
 
     private static final String MESSAGE_TEMPLATE_PROP = "messageTemplate";
-    private static final String MESSAGE_TEMPLATE_DEFAULT = "{1}: {2}";
+    private static final String MESSAGE_TEMPLATE_DEFAULT = "{5}:{1}: {2}";
 
-    @Property(label = "Logger", name=LOGGER_NAME_PROP, value=LOGGER_NAME_DEFAULT,
-              description = "Name of the logger to log to.")
+    @Property(label = "Logger", name = LOGGER_NAME_PROP, value = LOGGER_NAME_DEFAULT, description = "Name of the logger to log to.")
     private Logger jmxLog = null;
 
-    @Property(label = "Message Template", name=MESSAGE_TEMPLATE_PROP, value = MESSAGE_TEMPLATE_DEFAULT,
-              description = "{0}: Type {1}: Name of property, {2}: Value of property, {3}: Bean pattern, {4}: Property pattern")
+    @Property(label = "Message Template", name = MESSAGE_TEMPLATE_PROP, value = MESSAGE_TEMPLATE_DEFAULT, description = "{0}: Type {1}: Name of property, {2}: Value of property, {3}: Bean pattern, {4}: Property pattern, {5}: mBean path and name")
     private String messageTemplate = MESSAGE_TEMPLATE_DEFAULT;
 
     @VisibleForTesting
     static final String DEFAULT_SEARCH_CONFIG = ".*replication.*type=agent.*id=\"publish\".*|QueueNumEntries";
-    @Property(unbounded = PropertyUnbounded.ARRAY, cardinality=10, label="Search", description="Regex Pattern for jmx-bean and attribute in format beanpattern|attributpattern", value=DEFAULT_SEARCH_CONFIG)
+    @Property(unbounded = PropertyUnbounded.ARRAY, cardinality = 10, label = "Search", description = "Regex Pattern for jmx-bean and attribute in format beanpattern|attributpattern", value = DEFAULT_SEARCH_CONFIG)
     static final String SEARCH_CONFIG = "jmxtolog.search.configs";
 
     @VisibleForTesting
@@ -62,7 +58,8 @@ public class JmxToLogService implements Runnable {
     @Activate
     protected void activate(final Map<String, Object> props) {
         searchConfigs = new CopyOnWriteArrayList<>(
-            parseSearchConfigs(PropertiesUtil.toStringArray(props.get(SEARCH_CONFIG), new String[]{DEFAULT_SEARCH_CONFIG})));
+                parseSearchConfigs(PropertiesUtil.toStringArray(props.get(SEARCH_CONFIG),
+                        new String[] { DEFAULT_SEARCH_CONFIG })));
 
         messageTemplate = PropertiesUtil.toString(props.get(MESSAGE_TEMPLATE_PROP), MESSAGE_TEMPLATE_DEFAULT);
         jmxLog = LoggerFactory.getLogger(PropertiesUtil.toString(props.get(LOGGER_NAME_PROP), LOGGER_NAME_DEFAULT));
@@ -79,13 +76,15 @@ public class JmxToLogService implements Runnable {
             final int split = StringUtils.indexOf(patternLine, '|');
             final String beanPattern;
             final String attrPattern;
-            if(split<0) {
+            if (split < 0) {
                 beanPattern = patternLine;
                 attrPattern = ".*";
-                CLASS_LOG.info("Assuming attribute pattern \".*\" to output all attributes since configuration line \"{}\" does not contain separator '|'.", patternLine);
+                CLASS_LOG.info(
+                        "Assuming attribute pattern \".*\" to output all attributes since configuration line \"{}\" does not contain separator '|'.",
+                        patternLine);
             } else {
                 beanPattern = StringUtils.substring(patternLine, 0, split);
-                attrPattern = StringUtils.substring(patternLine, split+1);
+                attrPattern = StringUtils.substring(patternLine, split + 1);
             }
 
             CLASS_LOG.info("Adding bean \"{}\", attribute \"{}\" to search configuration", beanPattern, attrPattern);
@@ -116,7 +115,8 @@ public class JmxToLogService implements Runnable {
     private void logJmxValues(final SearchConfig searchConfig) {
         for (ObjectName mBean : readJmxService.mBeans(searchConfig.getNamePattern())) {
             try {
-                for (ReadJmxService.MBeanAttribute mBeanAttribute : readJmxService.attributes(mBean, searchConfig.getAttributePattern())) {
+                for (ReadJmxService.MBeanAttribute mBeanAttribute : readJmxService.attributes(mBean,
+                        searchConfig.getAttributePattern())) {
                     log(mBeanAttribute, searchConfig);
                 }
             } catch (NoSuchAttributeException nsae) {
@@ -130,11 +130,11 @@ public class JmxToLogService implements Runnable {
 
     @VisibleForTesting
     void log(final ReadJmxService.MBeanAttribute mBeanAttribute,
-             final SearchConfig searchConfig) {
-        if(jmxLog !=null) {
+            final SearchConfig searchConfig) {
+        if (jmxLog != null) {
             final String message = MessageFormat.format(messageTemplate,
                     mBeanAttribute.type(), mBeanAttribute.name(), mBeanAttribute.value(),
-                    searchConfig.getNamePattern(), searchConfig.getAttributePattern());
+                    searchConfig.getNamePattern(), searchConfig.getAttributePattern(), mBeanAttribute.mbean());
             jmxLog.info(message);
         }
     }

--- a/src/main/java/df/aem/jmx2log/impl/ReadJmxServiceImpl.java
+++ b/src/main/java/df/aem/jmx2log/impl/ReadJmxServiceImpl.java
@@ -31,17 +31,18 @@ public class ReadJmxServiceImpl implements ReadJmxService {
     public Iterable<ObjectName> mBeans(final String pattern) throws NoSuchMBeanException {
         final Set<ObjectName> objectNames = server.queryNames(null, new QueryExp() {
             @Override
-            public boolean apply(ObjectName name)  {
+            public boolean apply(ObjectName name) {
                 return name.toString().matches(pattern);
             }
 
             @Override
             public void setMBeanServer(MBeanServer s) {
-                // We already know the server we run the query on - if ever interested in that information.
+                // We already know the server we run the query on - if ever interested in that
+                // information.
             }
         });
 
-        if(objectNames.isEmpty()) {
+        if (objectNames.isEmpty()) {
             throw new NoSuchMBeanException(pattern);
         }
         return objectNames;
@@ -57,38 +58,45 @@ public class ReadJmxServiceImpl implements ReadJmxService {
             throws CouldNotReadJmxValueException {
         try {
             final MBeanAttributeInfo[] attributes = server.getMBeanInfo(mBean).getAttributes();
-            final List<MBeanAttribute> resultAttributes  = new ArrayList<>();
+            final List<MBeanAttribute> resultAttributes = new ArrayList<>();
             for (final MBeanAttributeInfo attribute : attributes) {
 
+                final String mbean = mBean.toString();
                 final String name = attribute.getName();
                 final String type = attribute.getType();
                 final Object value = server.getAttribute(mBean, name);
                 if (name.matches(namePattern))
 
-                resultAttributes.add(new MBeanAttribute() {
-                    @Override
-                    public String name() {
-                        return name;
-                    }
+                    resultAttributes.add(new MBeanAttribute() {
+                        @Override
+                        public String mbean() {
+                            return mbean;
+                        }
 
-                    @Override
-                    public String type() {
-                        return type;
-                    }
+                        @Override
+                        public String name() {
+                            return name;
+                        }
 
-                    @Override
-                    public Object value() {
-                        return value;
-                    }
-                });
+                        @Override
+                        public String type() {
+                            return type;
+                        }
+
+                        @Override
+                        public Object value() {
+                            return value;
+                        }
+                    });
 
             }
 
-            if(resultAttributes.isEmpty()) {
+            if (resultAttributes.isEmpty()) {
                 throw new NoSuchAttributeException(mBean, namePattern);
             }
             return resultAttributes;
-        } catch (RuntimeMBeanException | InstanceNotFoundException | IntrospectionException | ReflectionException | MBeanException | AttributeNotFoundException e) {
+        } catch (RuntimeMBeanException | InstanceNotFoundException | IntrospectionException | ReflectionException
+                | MBeanException | AttributeNotFoundException e) {
             throw new CouldNotReadJmxValueException(e);
         }
     }


### PR DESCRIPTION
It was difficult to find out which mbean the mbean-property was coming from.

OLD log-pattern: 
`07.12.2022 12:52:00.083 *INFO* [sling-default-2-df.aem.jmx2log.impl.JmxToLogService.23865] jmx2log status: CRITICAL`

NEW log-pattern:
`07.12.2022 13:56:00.097 *INFO* [sling-default-4-df.aem.jmx2log.impl.JmxToLogService.23885] jmx2log org.apache.sling.healthcheck:type=HealthCheck,name=slingJobs:status: CRITICAL`

Updates in Log-pattern:
_{0}: Type
{1}: Name of property
{2}: Value of property
{3}: Bean pattern
{4}: Property pattern (messageTemplate)_
**{5}: mBean path and name**

OLD Default log pattern:
`{5}:{1}: {2}`

NEW Default log pattern:
`{5}:{1}: {2}`